### PR TITLE
Add function to test if windows version if equal or above RS1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Once referenced, uatools.js allows you to call:
 * UATOOLS.GetOperatingSystem()
 * UATOOLS.IsMobile()
 * UATOOLS.IsTablet()
+* UATOOLS.IsWindowsVersionEqualOrAboveRS1()
 
 Feel free to contribute to get even more accurate results!
 

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
             <div class="col-xs-3 col-md-3 head">Operating system</div>
             <div class="col-xs-9 col-md-9" id="OS"></div>
         </div>
-         <h1>winver.js</h1>
+        <hr />
         <div class="row">
             <div class="col-xs-3 col-md-3 head">Is Windows Version >= RS1?</div>
             <div class="col-xs-9 col-md-9" id="IsWindowsVersionEqualOrAboveRS1"></div>

--- a/index.html
+++ b/index.html
@@ -61,12 +61,21 @@
             <div class="col-xs-3 col-md-3 head">Operating system</div>
             <div class="col-xs-9 col-md-9" id="OS"></div>
         </div>
+         <h1>winver.js</h1>
+        <div class="row">
+            <div class="col-xs-3 col-md-3 head">Is Windows Version >= RS1?</div>
+            <div class="col-xs-9 col-md-9" id="IsWindowsVersionEqualOrAboveRS1"></div>
+        </div>
     </div>
     <script>
         document.getElementById("currentUA").innerHTML = UATOOLS.GetUserAgentString();
         document.getElementById("isMobile").innerHTML = UATOOLS.IsTablet() ? "Running on tablet device" : UATOOLS.IsMobile() ? "Running on mobile device" : "Running on desktop device";
         document.getElementById("store").innerHTML = UATOOLS.GetStore();
         document.getElementById("OS").innerHTML = UATOOLS.GetOperatingSystem();
+        
+        //winver
+        document.getElementById("IsWindowsVersionEqualOrAboveRS1").innerHTML = UATOOLS.IsWindowsVersionEqualOrAboveRS1();
+        
     </script>
 </body>
 </html>

--- a/uatools.js
+++ b/uatools.js
@@ -105,4 +105,40 @@
 
         return "Unknown operating system";
     }
+
+    UATOOLS.IsOpera = function () {
+        // Opera 8.0+
+        return (!!window.opr && !!opr.addons) || !!window.opera || navigator.userAgent.indexOf(' OPR/') >= 0;
+    }
+
+    UATOOLS.IsFirefox = function () {
+        // Firefox 1.0+
+        return typeof InstallTrigger !== 'undefined';
+    }
+
+    UATOOLS.IsSafari = function () {
+        // Safari <= 9 "[object HTMLElementConstructor]" 
+        return Object.prototype.toString.call(window.HTMLElement).indexOf('Constructor') > 0;
+    }
+
+    UATOOLS.IsIE = function () {
+        // Internet Explorer 6-11
+        return /*@cc_on!@*/false || !!document.documentMode;
+    }
+
+    UATOOLS.IsEdge = function () {
+        // Edge 20+
+        return !UATOOLS.IsIE() && !!window.StyleMedia;
+    }
+
+    UATOOLS.IsChrome = function () {
+        // Chrome 1+
+        return !!window.chrome && !!window.chrome.webstore;
+    }
+
+    UATOOLS.IsBlink = function () {
+        // Blink engine detection
+        return (UATOOLS.IsChrome() || UATOOLS.IsOpera()) && !!window.CSS;
+    }
+
 })(UATOOLS || (UATOOLS = {}));

--- a/uatools.js
+++ b/uatools.js
@@ -151,20 +151,14 @@
         //Hack using canvas and font size which was handled differently previous to RS1 (Lower than 1607)
         var context = document.createElement('canvas').getContext('2d');
 
-        context.font = '64px Segoe UI Emoji'
-        var width = context.measureText('\uD83D\uDC31\u200D\uD83D\uDC64').width
+        context.font = '64px Segoe UI Emoji';
+        var width = context.measureText('\uD83D\uDC31\u200D\uD83D\uDC64').width;
 
         if (UATOOLS.IsChrome() || UATOOLS.IsFirefox() || UATOOLS.IsOpera() || UATOOLS.IsEdge()) {
-            if (width <= 90) {
-                return true;
-            } 
-            return false;
+            return width <= 90;
         }
         else if(UATOOLS.IsIE()){
-            if (width > 128) {
-                return true;
-            } 
-            return false;
+            return width > 128;
         }
         
         return false;

--- a/uatools.js
+++ b/uatools.js
@@ -141,4 +141,33 @@
         return (UATOOLS.IsChrome() || UATOOLS.IsOpera()) && !!window.CSS;
     }
 
+     // Features
+    UATOOLS.IsWindowsVersionEqualOrAboveRS1 = function () {
+        // is it Windows 10 ?
+        if (currentLowerUA.indexOf("windows nt 10") < 0) {
+            return false;
+        }
+
+        //Hack using canvas and font size which was handled differently previous to RS1 (Lower than 1607)
+        var context = document.createElement('canvas').getContext('2d');
+
+        context.font = '64px Segoe UI Emoji'
+        var width = context.measureText('\uD83D\uDC31\u200D\uD83D\uDC64').width
+
+        if (UATOOLS.IsChrome() || UATOOLS.IsFirefox() || UATOOLS.IsOpera() || UATOOLS.IsEdge()) {
+            if (width <= 90) {
+                return true;
+            } 
+            return false;
+        }
+        else if(UATOOLS.IsIE()){
+            if (width > 128) {
+                return true;
+            } 
+            return false;
+        }
+        
+        return false;
+    }
+
 })(UATOOLS || (UATOOLS = {}));


### PR DESCRIPTION
Works for : 
- Firefox
- Chrome
- Internet Explorer
- Edge
- Opera

Tested using :
- Windows 10 over RS1 (Version: 1607, OS Build: 14393.321)
- Windows 10 under RS1 (Version: 1511, OS Build: 10586.164)
- Last version of browsers

Index.html sample is updated to display result for this new function:
![image](https://cloud.githubusercontent.com/assets/1480170/19500317/d0dce24c-9550-11e6-86da-2f0aecd8d766.png)
