### PR TITLE
Add the download in win store button

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Once referenced, uatools.js allows you to call:
 Experimental:
 * UATOOLS.IsWindowsAnniversaryUpdateOrAbove()
 
-Or use the windows store button which only appear when your website is running on Windows Anniversary version or bigger.
+You can add a windows store button which only appear when your website is running on Windows Anniversary version or bigger.
 
 First step: reference the uatools.js file.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,11 @@ First step: reference the uatools.js file.
 
 Then add an anchor :
 ``` 
-<a class="winstore-link" data-winstore-id="9wzdncrfj364" data-winstore-cid="test" data-winstore-badge-size="small"></a>
+<a  class="winstore-link" 
+    data-winstore-id="9wzdncrfj364" 
+    data-winstore-cid="test" 
+    data-winstore-badge-size="small">
+</a>
 ```
 
 Parameters are:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,26 @@ Once referenced, uatools.js allows you to call:
 * UATOOLS.GetOperatingSystem()
 * UATOOLS.IsMobile()
 * UATOOLS.IsTablet()
-* UATOOLS.IsWindowsVersionEqualOrAboveRS1()
+
+Experimental:
+* UATOOLS.IsWindowsAnniversaryUpdateOrAbove()
+
+Or use the windows store button which only appear when your website is running on Windows Anniversary version or bigger.
+
+First step: reference the uatools.js file.
+
+Then add an anchor :
+``` 
+<a class="winstore-link" data-winstore-id="9wzdncrfj364" data-winstore-cid="test" data-winstore-badge-size="small"></a>
+```
+
+Parameters are:
+- ```class="winstore-link"```: **mandatory** for the tool to recognize this link as a Windows store link
+- ```data-winstore-id="YOURAPPIDINSTORE"```: **mandatory** for the tool to create the link
+- ```data-winstore-cid="YOURCAMPAINID"```: **optional** for the tool to create the link
+- ```data-winstore-badge-size="small"```: **optional** size of the generated button (small|medium|large), default = medium
+
+You can have as many of them as you want our your page. 
 
 Feel free to contribute to get even more accurate results!
 

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
             <div class="col-xs-3 col-md-3 head">Operating system</div>
             <div class="col-xs-9 col-md-9" id="OS"></div>
         </div>
-         <h1>winver.js</h1>
+        <hr />
         <div class="row">
             <div class="col-xs-3 col-md-3 head">Is Windows Version >= RS1?</div>
             <div class="col-xs-9 col-md-9" id="IsWindowsVersionEqualOrAboveRS1"></div>

--- a/index.html
+++ b/index.html
@@ -66,6 +66,7 @@
             <div class="col-xs-3 col-md-3 head">Is Windows Version >= RS1?</div>
             <div class="col-xs-9 col-md-9" id="IsWindowsAnniversaryUpdateOrAbove"></div>
         </div>
+        <hr />
         <div class="row">
             <div class="col-xs-3 col-md-3 head">
                 <p>Windows Centennial App Button (if you do not see it, your Windows version is not compatible)</p> 

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
         <hr />
         <div class="row">
             <div class="col-xs-3 col-md-3 head">Is Windows Version >= RS1?</div>
-            <div class="col-xs-9 col-md-9" id="IsWindowsVersionEqualOrAboveRS1"></div>
+            <div class="col-xs-9 col-md-9" id="IsWindowsAnniversaryUpdateOrAbove"></div>
         </div>
     </div>
     <script>
@@ -74,7 +74,7 @@
         document.getElementById("OS").innerHTML = UATOOLS.GetOperatingSystem();
         
         //winver
-        document.getElementById("IsWindowsVersionEqualOrAboveRS1").innerHTML = UATOOLS.IsWindowsVersionEqualOrAboveRS1();
+        document.getElementById("IsWindowsAnniversaryUpdateOrAbove").innerHTML = UATOOLS.IsWindowsAnniversaryUpdateOrAbove();
         
     </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -66,6 +66,20 @@
             <div class="col-xs-3 col-md-3 head">Is Windows Version >= RS1?</div>
             <div class="col-xs-9 col-md-9" id="IsWindowsAnniversaryUpdateOrAbove"></div>
         </div>
+        <div class="row">
+            <div class="col-xs-3 col-md-3 head">
+                <p>Windows Centennial App Button (if you do not see it, your Windows version is not compatible)</p> 
+                <ul style="text-align:left;">
+                    <li>3 different sizes (small, medium, large)</li>
+                    <li>First one got a fake campain id</li>
+                </ul>
+            </div>
+            <div class="col-xs-9 col-md-9" id="IsWindowsAnniversaryUpdateOrAbove">
+                <a class="winstore-link" data-winstore-id="9wzdncrfj364" data-winstore-cid="test" data-winstore-badge-size="small"></a>
+                <a class="winstore-link" data-winstore-id="9wzdncrfj364"></a>
+                <a class="winstore-link" data-winstore-id="9wzdncrfj364"data-winstore-badge-size="large"></a>
+            </div>
+        </div>
     </div>
     <script>
         document.getElementById("currentUA").innerHTML = UATOOLS.GetUserAgentString();

--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
         <hr />
         <div class="row">
             <div class="col-xs-3 col-md-3 head">
-                <p>Windows Centennial App Button (if you do not see it, your Windows version is not compatible)</p> 
+                <p>Windows Store App Button (if you do not see it, your Windows version is not compatible)</p> 
                 <ul style="text-align:left;">
                     <li>3 different sizes (small, medium, large)</li>
                     <li>First one got a fake campain id</li>

--- a/uatools.js
+++ b/uatools.js
@@ -141,8 +141,8 @@
         return (UATOOLS.IsChrome() || UATOOLS.IsOpera()) && !!window.CSS;
     }
 
-     // Features
-    UATOOLS.IsWindowsVersionEqualOrAboveRS1 = function () {
+     // Experimental
+    UATOOLS.IsWindowsAnniversaryUpdateOrAbove = function () {
         // is it Windows 10 ?
         if (currentLowerUA.indexOf("windows nt 10") < 0) {
             return false;

--- a/uatools.js
+++ b/uatools.js
@@ -164,4 +164,67 @@
         return false;
     }
 
+    // Experimental
+    window.addEventListener("DOMContentLoaded", function() {
+        var storeLinks = document.getElementsByClassName("winstore-link");
+
+        for(var i = 0, len = storeLinks.length; i < len; i++) {
+            var storeLink = storeLinks[i];
+
+            //if windows version below anniversary
+            if(!UATOOLS.IsWindowsAnniversaryUpdateOrAbove()){
+                //hide the link
+                storeLink.style.display = "none";
+                return;
+            }
+
+            var campainid, storeid;
+
+            if(storeLink.attributes["data-winstore-id"]) 
+                storeid = storeLink.attributes["data-winstore-id"].value;
+
+            if(storeid){
+                //Get campain id if there is any
+                if(storeLink.attributes["data-winstore-cid"]) 
+                    campainid = storeLink.attributes["data-winstore-cid"].value;
+
+                //default value for size
+                var size = "medium";
+                if(storeLink.attributes["data-winstore-badge-size"]) 
+                    size = storeLink.attributes["data-winstore-badge-size"].value || size;
+            
+                var img = document.createElement("img");
+                img.src = "https://assets.windowsphone.com/f2f77ec7-9ba9-4850-9ebe-77e366d08adc/English_Get_it_Win_10_InvariantCulture_Default.png";
+                img.alt = "Get it on Windows 10";
+                
+                size = size || "medium";
+                switch(size){
+                    case "small":
+                        img.height = 20;
+                        break;
+                    case "medium":
+                        img.height = 40;
+                        break;
+                    case "large":
+                        img.height = 80;
+                        break;
+                }
+
+                storeLink.appendChild(img);
+                storeLink.href = "https://www.microsoft.com/store/apps/" + storeid;
+
+                if(campainid)
+                    storeLink.href += "&cid=" + campainid;
+
+                campainid = undefined;
+                storeid = undefined;
+            }
+            else{
+                //hide the link
+                storeLink.style.display = "none";
+                console.log("Found a Windows Store anchor with no data-winstore-id. Please specify it.");
+            }
+        }
+    }, false);
+
 })(UATOOLS || (UATOOLS = {}));

--- a/uatools.js
+++ b/uatools.js
@@ -154,8 +154,12 @@
         context.font = '64px Segoe UI Emoji';
         var width = context.measureText('\uD83D\uDC31\u200D\uD83D\uDC64').width;
 
-        if (UATOOLS.IsChrome() || UATOOLS.IsFirefox() || UATOOLS.IsOpera() || UATOOLS.IsEdge()) {
+        if (UATOOLS.IsChrome() || UATOOLS.IsFirefox() || UATOOLS.IsOpera()) {
             return width <= 90;
+        }
+        else if(UATOOLS.IsEdge()){
+            var windowsBuildNumber = currentLowerUA.match("edge/[0-9]+.([0-9]+)")[1];
+            return windowsBuildNumber >= 14393
         }
         else if(UATOOLS.IsIE()){
             return width > 128;


### PR DESCRIPTION
Add the windows store button which only appear when your website is running on Windows Anniversary version or bigger.

First step: reference the uatools.js file.

Then add an anchor :
``` 
<a  class="winstore-link" 
    data-winstore-id="9wzdncrfj364" 
    data-winstore-cid="test" 
    data-winstore-badge-size="small">
</a>
```

Parameters are:
- ```class="winstore-link"```: **mandatory** for the tool to recognize this link as a Windows store link
- ```data-winstore-id="YOURAPPIDINSTORE"```: **mandatory** for the tool to create the link
- ```data-winstore-cid="YOURCAMPAINID"```: **optional** for the tool to create the link
- ```data-winstore-badge-size="small"```: **optional** size of the generated button (small|medium|large), default = medium

You can have as many of them as you want our your page. 

<img src="https://assets.windowsphone.com/f2f77ec7-9ba9-4850-9ebe-77e366d08adc/English_Get_it_Win_10_InvariantCulture_Default.png" height="20" alt="Download windows app in store image">
<img src="https://assets.windowsphone.com/f2f77ec7-9ba9-4850-9ebe-77e366d08adc/English_Get_it_Win_10_InvariantCulture_Default.png" height="40" alt="Download windows app in store image">
<img src="https://assets.windowsphone.com/f2f77ec7-9ba9-4850-9ebe-77e366d08adc/English_Get_it_Win_10_InvariantCulture_Default.png" height="80" alt="Download windows app in store image">

Feel free to contribute to get even more accurate results!